### PR TITLE
Fix: Correcting Package Name in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ To use this library in your Rust application, add the following to your Cargo.to
 
 ```toml
 [dependencies]
-tonlib-rs = "0.5.0"
+tonlib = "0.5.1"
 ```
 
 Then, in your Rust code, you can import the library with:
 
 ```rust
-use tonlib_rs;
+use tonlib;
 ```
 
 ### Cell


### PR DESCRIPTION
Hi!

I noticed a minor discrepancy between the package name listed in the Cargo file (`tonlib`) and the name used in the ReadMe (`tonlib-rs`). This could potentially cause some confusion during installation and usage.

This PR updates the package name throughout the documentation to `tonlib`, aligning it with the version uploaded on crates.io. I believe this change reflects the original intention and ensures uniformity across all references to the package.

I would like to take this opportunity to express my appreciation for the excellent work done by your team.