### PR TITLE
Fix spawning smc_forget future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ pbkdf2 = "0.11"
 reqwest = "0.11"
 tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"
-tonlib-sys = "2023.6.0" 
+tonlib-sys = "2023.6.1"
 
 [dev-dependencies]
 tokio-test = "0.4"


### PR DESCRIPTION
smc_forget call must be spawned asynchronously upon dropping TonContractState