### PR TITLE
Implement `get_config_param` and Fix issue with masterchain addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonlib"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 description = "Rust SDK for The Open Network"
 license = "MIT"

--- a/src/cell/builder.rs
+++ b/src/cell/builder.rs
@@ -105,8 +105,8 @@ impl CellBuilder {
     pub fn store_raw_address(&mut self, val: &TonAddress) -> anyhow::Result<&mut Self> {
         self.store_u8(2, 0b10u8)?;
         self.store_bit(false)?;
-        let wc = (val.workchain & 0xff) as i8;
-        self.store_i8(8, wc)?;
+        let wc = (val.workchain & 0xff) as u8;
+        self.store_u8(8, wc)?;
         self.store_slice(&val.hash_part)?;
         Ok(self)
     }

--- a/src/client/types.rs
+++ b/src/client/types.rs
@@ -13,7 +13,7 @@ use tokio::sync::broadcast;
 
 use crate::tl::types::{
     AccountAddress, BlockId, BlockIdExt, BlocksAccountTransactionId, BlocksHeader,
-    BlocksMasterchainInfo, BlocksShards, BlocksTransactions, FullAccountState,
+    BlocksMasterchainInfo, BlocksShards, BlocksTransactions, ChainConfigInfo, FullAccountState,
     InternalTransactionId, RawFullAccountState, RawTransactions,
 };
 use crate::tl::TonNotification;
@@ -311,6 +311,15 @@ pub trait TonFunctions {
         match result {
             TonResult::BlocksHeader(header) => Ok(header),
             r => Err(anyhow!("Expected BlocksHeader, got: {:?}", r)),
+        }
+    }
+
+    async fn get_config_param(&self, mode: u32, param: u32) -> anyhow::Result<ChainConfigInfo> {
+        let func = TonFunction::GetConfigParam { mode, param };
+        let result = self.invoke(&func).await?;
+        match result {
+            TonResult::ChainConfigInfo(result) => Ok(result),
+            r => Err(anyhow!("Expected ChainConfigInfo, got: {:?}", r)),
         }
     }
 

--- a/src/tl/function.rs
+++ b/src/tl/function.rs
@@ -87,6 +87,12 @@ pub enum TonFunction {
         lt: i64,
         utime: i32,
     },
+    // tonlib_api.tl, line 288
+    #[serde(rename = "getConfigParam")]
+    GetConfigParam {
+        mode: u32,
+        param: u32,
+    },
     // tonlib_api.tl, line 314
     #[serde(rename = "blocks.getTransactions")]
     BlocksGetTransactions {

--- a/src/tl/result.rs
+++ b/src/tl/result.rs
@@ -4,8 +4,8 @@ use strum::IntoStaticStr;
 
 use crate::tl::types::{
     BlockIdExt, BlocksHeader, BlocksMasterchainInfo, BlocksShards, BlocksTransactions,
-    FullAccountState, LogVerbosityLevel, OptionsInfo, RawExtMessageInfo, RawFullAccountState,
-    RawTransactions, SmcInfo, SmcRunResult, UpdateSyncState,
+    ChainConfigInfo, FullAccountState, LogVerbosityLevel, OptionsInfo, RawExtMessageInfo,
+    RawFullAccountState, RawTransactions, SmcInfo, SmcRunResult, UpdateSyncState,
 };
 
 #[derive(IntoStaticStr, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
@@ -60,6 +60,9 @@ pub enum TonResult {
     // tonlib_api.tl, line 217
     #[serde(rename = "blocks.header")]
     BlocksHeader(BlocksHeader),
+    // tonlib_api.tl, line 228
+    #[serde(rename = "configInfo")]
+    ChainConfigInfo(ChainConfigInfo),
 }
 
 impl TonResult {

--- a/src/tl/types.rs
+++ b/src/tl/types.rs
@@ -6,6 +6,7 @@ use serde_aux::prelude::*;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
+use crate::tl::stack::TvmCell;
 use crate::tl::stack::TvmStack;
 use crate::tl::Base64Standard;
 
@@ -527,6 +528,12 @@ pub struct BlocksHeader {
     pub gen_utime: i64,
     pub vert_seqno: i32,
     pub prev_blocks: Vec<BlockIdExt>,
+}
+
+// tonlib_api.tl, line 228
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChainConfigInfo {
+    pub config: TvmCell,
 }
 
 #[cfg(test)]

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,0 +1,18 @@
+use tonlib::cell::BagOfCells;
+use tonlib::client::TonFunctions;
+
+mod common;
+
+#[tokio::test]
+async fn test_config_works() -> anyhow::Result<()> {
+    common::init_logging();
+    let client = &common::new_test_client().await?;
+    let info = client.get_config_param(0u32, 34u32).await?;
+    let config_data = info.config.bytes;
+    let bag = BagOfCells::parse(config_data.as_slice())?;
+    let config_cell = bag.single_root()?;
+    let mut parser = config_cell.parser();
+    let n = parser.load_u8(8)?;
+    assert!(n == 0x12u8);
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces the following modifications to the library:

1. Implements the `get_config_param` function, enabling the retrieval of config cells and the reading of data from them.
2. Resolves a problematic implementation of store_address that affects masterchain addresses. The issue can be reproduced via the example provided.
```rust
use anyhow::{bail, Ok, Result};
use tonlib::address::TonAddress;
use tonlib::cell::CellBuilder;

fn test_address(addr_: &str) -> Result<()> {
    let addr = TonAddress::from_base64_url(addr_)?;
    let c = CellBuilder::new().store_address(&addr)?.build()?;
    let mut p = c.parser();
    let c_ = p.load_u8(2)?;
    let anycast = p.load_bit()?;
    let wc = p.load_u8(8)? as i8;
    let hash = p.load_uint(256)?;
    println!(
        "constructor: {}, anycast?: {}, wc: {}, hash: {}",
        c_, anycast, wc, hash
    );
    p = c.parser();
    let addr = p.load_address();
    if addr.is_err() {
        bail!("Couldn't load address");
    }
    if !addr.unwrap().to_base64_url().eq(addr_) {
        bail!("Serialized and deserialized addr don't match!");
    }
    Ok(())
}
fn main() -> Result<()> {
    // This is a normal addr (wc = 0) | Will work as expected
    let wc_addr = "EQATcgoK4eGMgackgnMF8aHUJLR0Pq_U0hzcmiwAhPbEMmw_";
    let r = test_address(wc_addr);
    assert!(r.is_ok());
    // This is a mc addr (wc = -1) | Will fail
    let mc_addr = "Ef8HujUcsUlU_vClVUnZRqHQfnhvrc8C241HOIqRL5XDe2P7";
    let r = test_address(mc_addr);
    r.unwrap();

    Ok(())
}
```
This code should ideally run without errors for both addresses. However, it fails for the second one, with unexpected changes in constructor and anycast flag values, as seen in the log:
```log
constructor: 2, anycast?: false, wc: 0, hash: 8795433999317782811755257230391905142775921687175506829826532924721519313970
constructor: 3, anycast?: true, wc: -1, hash: 3495190060236973450600321995803361255911842138770757834326427501877748155259
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Couldn't load address', src/main.rs:35:7
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
A deeper look at the code reveals that the problem possibly arises from how `wc` is masked with `0xff` but then stored as an `i8`, potentially causing issues due to sign bits. Adjusting the code to use `store_u8` instead seems to fix the issue:
```rust
    /// Stores address without optimizing hole address
    pub fn store_raw_address(&mut self, val: &TonAddress) -> anyhow::Result<&mut Self> {
        self.store_u8(2, 0b10u8)?;
        self.store_bit(false)?;
        let wc = (val.workchain & 0xff) as i8;
        self.store_i8(8, wc)?;
        self.store_slice(&val.hash_part)?;
        Ok(self)
    }
```


