### PR TITLE
fix: c_char casting issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonlib"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 description = "Rust SDK for The Open Network"
 license = "MIT"

--- a/src/tl.rs
+++ b/src/tl.rs
@@ -1,4 +1,5 @@
 use std::ffi::CStr;
+use std::os::raw::c_char;
 
 use anyhow::Result;
 use base64_serde::base64_serde_type;
@@ -87,7 +88,7 @@ impl TlTonClient {
             }
             let c_str_bytes = c_str_slice.to_bytes();
             let (result, extra) =
-                unsafe { deserialize_result_extra(c_str_bytes.as_ptr() as *const i8) };
+                unsafe { deserialize_result_extra(c_str_bytes.as_ptr() as *const c_char) };
             Some((result, extra))
         }
     }


### PR DESCRIPTION
When deserializing using native methods in [tl.rs](https://github.com/ston-fi/tonlib-rs/blob/de21244f040e775f8412964bf5e2ff169bc87b9a/src/tl.rs#L90C72-L90C84), it's assumed that `c_char` is of type `i8` and therefore there is an unchecked cast for it. However, It appears that in some operating systems/archs the `c_char` is a `u8` type actually, which leads to errors in compiling for those systems. This PR fixes the issue by casting the value to `*const c_char` instead of `*const i8`, so it abstracts out any assumptions and uses the native type.