### PR TITLE
docs: remove mactex in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ sudo apt install build-essential cmake libsodium-dev libsecp256k1-dev lz4 liblz4
 
 For macOS:
 ```shell
-brew install --cask mactex
 brew install readline secp256k1 ccache pkgconfig cmake libsodium
 ```
 


### PR DESCRIPTION
does it really need latex for compile tonlib?

![image](https://github.com/user-attachments/assets/75cdcf65-4a85-411f-8b55-42dfda60c40e)

seems ton repo also not use that lib.

references: https://github.com/ton-blockchain/ton/blob/master/assembly/native/build-macos-shared.sh#L27-L28