### PR TITLE
feat: add Debug trait for WalletVersion and TonWallet

### DIFF
--- a/core/src/mnemonic.rs
+++ b/core/src/mnemonic.rs
@@ -2,6 +2,7 @@ mod error;
 
 use std::cmp;
 use std::collections::HashMap;
+use std::fmt;
 
 pub use error::*;
 use hmac::{Hmac, Mac};
@@ -36,6 +37,15 @@ pub struct Mnemonic {
 pub struct KeyPair {
     pub public_key: Vec<u8>,
     pub secret_key: Vec<u8>,
+}
+
+impl fmt::Debug for KeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("KeyPair")
+            .field("public_key", &self.public_key)
+            .field("secret_key", &"***REDACTED***")
+            .finish()
+    }
 }
 
 impl Mnemonic {

--- a/core/src/wallet.rs
+++ b/core/src/wallet.rs
@@ -74,7 +74,7 @@ lazy_static! {
     };
 }
 
-#[derive(PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum WalletVersion {
     V1R1,
     V1R2,
@@ -170,7 +170,7 @@ impl WalletVersion {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct TonWallet {
     pub key_pair: KeyPair,
     pub version: WalletVersion,
@@ -330,5 +330,26 @@ mod tests {
             .unwrap();
         assert_eq!(wallet_v4r2.address, expected_v4r2);
         Ok(())
+    }
+
+    use crate::wallet::KeyPair;
+    #[test]
+    fn test_debug_ton_wallet() {
+        let key_pair = KeyPair {
+            public_key: vec![1, 2, 3],
+            secret_key: vec![4, 5, 6],
+        };
+        let wallet = TonWallet {
+            key_pair,
+            version: WalletVersion::V4R2,
+            address: "EQBiMfDMivebQb052Z6yR3jHrmwNhw1kQ5bcAUOBYsK_VPuK"
+                .parse()
+                .unwrap(),
+            wallet_id: 42,
+        };
+
+        let debug_output = format!("{:?}", wallet);
+        let expected_output = "TonWallet { key_pair: KeyPair { public_key: [1, 2, 3], secret_key: \"***REDACTED***\" }, version: V4R2, address: EQBiMfDMivebQb052Z6yR3jHrmwNhw1kQ5bcAUOBYsK_VPuK, wallet_id: 42 }";
+        assert_eq!(debug_output, expected_output);
     }
 }


### PR DESCRIPTION
Added Debug implementation for WalletVersion and Ton Wallet.

This change simplifies debugging during TON integration with other protocols, especially when inspecting wallet structures. Sensitive data like secret_key is hidden (***REDACTED***) to maintain security